### PR TITLE
wcb: Add vlneval dependency

### DIFF
--- a/wcb.py
+++ b/wcb.py
@@ -34,6 +34,16 @@ package_descriptions = [
     #('ZYRE',     dict(incs=["zyre.h"], libs=['zyre'], pcname='libzyre', mandatory=False)),
     #('ZIO',      dict(incs=["zio/node.hpp"], libs=['zio'], pcname='libzio', mandatory=False,
     #                  extuses=("ZYRE","CZMQ","ZMQ"))),
+    (
+        'VLNEVAL',
+         dict(
+             incs      = [ "vlneval/struct/VarDict.h" ],
+             libs      = [ "vlneval" ],
+             pcname    = 'vlneval',
+             mandatory = False,
+             # extuses   = [ "TENSORFLOW", "BOOST" ]
+         )
+    ),
 
     # Note, this list may be modified (appended) in wscript files.
     # The list here represents the minimum wire-cell-toolkit requires.


### PR DESCRIPTION
Hi @brettviren,

Sorry, if I misunderstood your comment, but I am trying to open this PR agains Haiwang's branch of `waf-tools`. This is a tiny PR that adds a code to detect `vlneval` library on a system. It is intended to be used in https://github.com/usert5432/wcp-uboone-bdt/tree/eval_dlee_devel.

Could you please let me know if this PR is ok?

Additionally, you have mentioned that I should add a tensorflow dependency as well. The problem is that, the tensorflow dependency is a private dependency of the `vlneval` library. Correspondingly, I am not sure if I should expose it?